### PR TITLE
docs: add root README with repository overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Personal Tech Portfolios
+
+Welcome to my personal portfolio repository. This collection brings together my writing, technical projects, learning notes, and media work in one place.
+
+## Repository overview
+
+| Folder | Description |
+| --- | --- |
+| [`1-Book-Writing`](./1-Book-Writing/) | Book-writing projects and related material. |
+| [`2-Skillset-Showcase`](./2-Skillset-Showcase/) | Full-stack development, UI design, website design, and academic-site projects. |
+| [`3-Learning-and-Resources`](./3-Learning-and-Resources/) | Learning resources for French, computer science, finance, law, and reading. |
+| [`4-Media-and-Content`](./4-Media-and-Content/) | Media and content projects. |
+
+## Exploring the projects
+
+Open any folder above to explore that part of the portfolio. Individual projects may include their own README with specific setup, development, and usage instructions.
+
+## About this repository
+
+This repository is a living archive and will continue to grow as I learn, build, write, and create.


### PR DESCRIPTION
### Motivation

- Provide a concise entrypoint for the repository so visitors can quickly understand its purpose and structure. 
- Make it easier to navigate the main portfolio sections by listing the top-level folders and what they contain.

### Description

- Added a new file `README.md` at the repository root that includes a short introduction, a table linking to the four main folders, and brief exploration guidance. 
- The README links to `1-Book-Writing`, `2-Skillset-Showcase`, `3-Learning-and-Resources`, and `4-Media-and-Content` and describes each section. 
- The file was added to the working tree and committed; unrelated local changes were left untouched.

### Testing

- Ran `git diff --cached --check` and it completed without errors. 
- Verified the committed change contains only `README.md` with `test "$(git show --format= --name-only HEAD)" = "README.md"` and that the referenced directories exist by testing `for path in 1-Book-Writing 2-Skillset-Showcase 3-Learning-and-Resources 4-Media-and-Content; do test -d "$path"; done`, all of which passed. 
- Ran `git diff-tree --check HEAD^!` and a final verification script; all automated checks succeeded, and a pull request was not created because no remote/PR tool is available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78b19632fc832a8d792cf197582d00)